### PR TITLE
Improve pool information in lake spec

### DIFF
--- a/lake/crd.yaml
+++ b/lake/crd.yaml
@@ -40,6 +40,8 @@ spec:
                       type: string
                     last_updated:
                       type: string
+                    name:
+                      type: string
                     size:
                       type: number
                   type: object

--- a/lake/crd.yaml
+++ b/lake/crd.yaml
@@ -25,7 +25,7 @@ spec:
             properties:
               control:
                 properties:
-                  poll_interval_seconds:
+                  poll_interval:
                     properties:
                       intent:
                         type: number

--- a/lake/crd.yaml
+++ b/lake/crd.yaml
@@ -23,6 +23,16 @@ spec:
             type: object
           spec:
             properties:
+              control:
+                properties:
+                  poll_interval_seconds:
+                    properties:
+                      intent:
+                        type: number
+                      status:
+                        type: number
+                    type: object
+                type: object
               pools:
                 additionalProperties:
                   properties:

--- a/lake/deploy/cr.yaml
+++ b/lake/deploy/cr.yaml
@@ -2,3 +2,6 @@ apiVersion: digi.dev/v1
 kind: lake
 metadata:
   name: {{ .Values.name }}
+spec:
+  stats:
+    num_pools: 0

--- a/lake/deploy/cr.yaml
+++ b/lake/deploy/cr.yaml
@@ -3,5 +3,8 @@ kind: lake
 metadata:
   name: {{ .Values.name }}
 spec:
+  control:
+    poll_interval_seconds:
+      intent: 2.0
   stats:
     num_pools: 0

--- a/lake/deploy/cr.yaml
+++ b/lake/deploy/cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.name }}
 spec:
   control:
-    poll_interval_seconds:
+    poll_interval:
       intent: 2.0
   stats:
     num_pools: 0

--- a/lake/driver/event.py
+++ b/lake/driver/event.py
@@ -63,10 +63,9 @@ def parse_delete_pool(data_line):
         pools[pool_id] = None
         new_spec["pools"] = pools
         
-        HEADS_LOCK.acquire()
-        if pool_id in HEADS:
-            HEADS.pop(pool_id)
-        HEADS_LOCK.release()
+        with HEADS_LOCK:
+            if pool_id in HEADS:
+                HEADS.pop(pool_id)
             
     res, err = digi.util.patch_spec("digi.dev", "v1", "lakes", "lake", "default", new_spec)
     
@@ -87,10 +86,9 @@ def parse_new_pool(data_line):
     pool_id = data_line_dict["pool_id"]
     
     
-    pools[pool_id] = {} 
-    HEADS_LOCK.acquire()
-    HEADS[pool_id] = NULL_COMMIT_ID
-    HEADS_LOCK.release()
+    pools[pool_id] = {}
+    with HEADS_LOCK: 
+        HEADS[pool_id] = NULL_COMMIT_ID
     new_spec["pools"] = pools
     
     res, err = digi.util.patch_spec("digi.dev", "v1", "lakes", "lake", "default", new_spec)
@@ -99,9 +97,8 @@ def parse_commit(data_line):
     data_line_dict  = dict_from_data_line(data_line)
     pool_id = data_line_dict["pool_id"] 
     commit_id = data_line_dict["commit_id"]
-    HEADS_LOCK.acquire()    
-    HEADS[pool_id] = commit_id
-    HEADS_LOCK.release()
+    with HEADS_LOCK: 
+        HEADS[pool_id] = commit_id
     
 PARSE_FUNCTION_MAP = {
     "pool-new" : parse_new_pool,

--- a/lake/driver/event.py
+++ b/lake/driver/event.py
@@ -45,7 +45,7 @@ def dict_from_data_line(data_line):
         return None
 
 def parse_delete_pool(data_line):
-    spec = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")[0]
+    spec = digi.model.get()
     new_spec = {}
     
     stats = spec.get("stats", None)
@@ -67,11 +67,11 @@ def parse_delete_pool(data_line):
             if pool_id in HEADS:
                 HEADS.pop(pool_id)
             
-    res, err = digi.util.patch_spec("digi.dev", "v1", "lakes", "lake", "default", new_spec)
+    digi.model.patch(view_or_path=new_spec)
     
                 
 def parse_new_pool(data_line):
-    spec = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")[0]
+    spec = digi.model.get()
     new_spec = {}
     
     stats = spec.get("stats", {"num_pools" : 0})
@@ -85,13 +85,12 @@ def parse_new_pool(data_line):
     
     pool_id = data_line_dict["pool_id"]
     
-    
     pools[pool_id] = {}
     with HEADS_LOCK: 
         HEADS[pool_id] = NULL_COMMIT_ID
     new_spec["pools"] = pools
     
-    res, err = digi.util.patch_spec("digi.dev", "v1", "lakes", "lake", "default", new_spec)
+    digi.model.patch(view_or_path=new_spec)
     
 def parse_commit(data_line):
     data_line_dict  = dict_from_data_line(data_line)

--- a/lake/driver/handler.py
+++ b/lake/driver/handler.py
@@ -90,10 +90,10 @@ def poll_func():
         pool_count = get_branch_count_sum(name, curr_branches)
         
         #add count, HEADS, and timestamp to new spec
-        try: #use try-except in case we don't have values for head yet (generated from event parsing)
-            new_spec["pools"][pool_id] = {"head": event.HEADS[pool_id], "last_updated" : ts, "size": pool_count} #race on HEADS with event thread?
-        except:
-            new_spec["pools"][pool_id] = {"head": event.NULL_COMMIT_ID, "last_updated" : ts, "size": pool_count}
+        if pool_id in event.HEADS:
+            new_spec["pools"][pool_id] = {"head": event.HEADS[pool_id], "last_updated" : ts, "size": pool_count, "name" : name} #race on HEADS with event thread?
+        else:
+            new_spec["pools"][pool_id] = {"head": event.NULL_COMMIT_ID, "last_updated" : ts, "size": pool_count, "name" : name}
     
     #patch spec
     patch_existing_pools(new_spec)

--- a/lake/driver/handler.py
+++ b/lake/driver/handler.py
@@ -48,7 +48,7 @@ def get_branch_count_sum(pool_name, branches):
 def patch_existing_pools(new_spec):
     new_spec_pools = new_spec.get("pools", {})
     while True:
-        curr_spec, _, start_gen = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")
+        curr_spec, _, start_gen = digi.util.get_spec(digi.g, digi.v, digi.r, digi.n, digi.ns)
         curr_pools = curr_spec.get("pools", {})
         
         keys_to_remove = []
@@ -59,16 +59,16 @@ def patch_existing_pools(new_spec):
         for pop_key in keys_to_remove:
             new_spec_pools.pop(pop_key)
                 
-        _, rv, curr_gen = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")
+        _, rv, curr_gen = digi.util.get_spec(digi.g, digi.v, digi.r, digi.n, digi.ns)
         if start_gen < curr_gen:
             continue
         else:        
-            res, err = digi.util.patch_spec("digi.dev", "v1", "lakes", "lake", "default", new_spec, rv=rv)
+            res, err = digi.util.patch_spec(digi.g, digi.v, digi.r, digi.n, digi.ns, new_spec, rv=rv)
             return
         
 
 def poll_func():
-    curr_spec, _, _ = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")
+    curr_spec = digi.model.get()
     Timer(curr_spec["control"]["poll_interval"]["intent"], poll_func).start()
         
     new_spec = {"pools" : {}}

--- a/lake/driver/handler.py
+++ b/lake/driver/handler.py
@@ -87,12 +87,11 @@ def poll_func():
         pool_count = get_branch_count_sum(name, curr_branches)
         
         #add count, HEADS, and timestamp to new spec
-        event.HEADS_LOCK.acquire()
-        if pool_id in event.HEADS:
-            new_spec["pools"][pool_id] = {"head": event.HEADS[pool_id], "last_updated" : ts, "size": pool_count, "name" : name}
-        else: #do not update head if none is found
-            new_spec["pools"][pool_id] = {"last_updated" : ts, "size": pool_count, "name" : name}
-        event.HEADS_LOCK.release()
+        with event.HEADS_LOCK:
+            if pool_id in event.HEADS:
+                new_spec["pools"][pool_id] = {"head": event.HEADS[pool_id], "last_updated" : ts, "size": pool_count, "name" : name}
+            else: #do not update head if none is found
+                new_spec["pools"][pool_id] = {"last_updated" : ts, "size": pool_count, "name" : name}
     
     #patch spec
     patch_existing_pools(new_spec)

--- a/lake/driver/handler.py
+++ b/lake/driver/handler.py
@@ -7,7 +7,6 @@ import pyzed
 import event
 
 ZED_LAKE_URL = "http://localhost:9867"
-POLL_INTERVAL_SECONDS = 10.0
 SPAWNED_THREADS = []
 zed_client = pyzed.Client(base_url=ZED_LAKE_URL)
 
@@ -69,8 +68,9 @@ def patch_existing_pools(new_spec):
         
 
 def poll_func():
-    Timer(POLL_INTERVAL_SECONDS, poll_func).start()
-    
+    curr_spec, _, _ = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")
+    Timer(curr_spec["control"]["poll_interval_seconds"]["intent"], poll_func).start()
+        
     new_spec = {"pools" : {}}
     
     pool_query_pyzed = zed_client.query("from :pools")

--- a/lake/driver/handler.py
+++ b/lake/driver/handler.py
@@ -69,7 +69,7 @@ def patch_existing_pools(new_spec):
 
 def poll_func():
     curr_spec, _, _ = digi.util.get_spec("digi.dev", "v1", "lakes", "lake", "default")
-    Timer(curr_spec["control"]["poll_interval_seconds"]["intent"], poll_func).start()
+    Timer(curr_spec["control"]["poll_interval"]["intent"], poll_func).start()
         
     new_spec = {"pools" : {}}
     

--- a/lake/model.yaml
+++ b/lake/model.yaml
@@ -1,6 +1,8 @@
 group: digi.dev
 version: v1
 kind: lake
+control:
+  poll_interval_seconds: number
 stats:
   openapi:
     properties:

--- a/lake/model.yaml
+++ b/lake/model.yaml
@@ -2,7 +2,7 @@ group: digi.dev
 version: v1
 kind: lake
 control:
-  poll_interval_seconds: number
+  poll_interval: number
 stats:
   openapi:
     properties:

--- a/lake/model.yaml
+++ b/lake/model.yaml
@@ -13,6 +13,8 @@ pools:
   openapi:
     additionalProperties:
       properties:
+        name:
+          type: string
         head:
           type: string
         last_updated:


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
This PR adds additional information to the lake spec. 
1. Add human-readable names to each pool entry
2. Make the polling interval an attribute configurable with digi edit
3. Add a default for the pool count
4. Add a lock on HEADS to avoid race conditions between the event and polling threads

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/digi-project/digi/issues/39

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note NONE
```
