### PR TITLE
[cli] Add secrets, and add change EMQX digi to use secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,18 @@ ctx:
 install: | digi neat ctx
 	@mkdir $(HOMEDIR) >/dev/null 2>&1 || true
 	@mkdir $(HOMEDIR)/headscale >/dev/null 2>&1 || true
+	@mkdir $(HOMEDIR)/emqx >/dev/null 2>&1 || true
+	@mkdir $(HOMEDIR)/secrets >/dev/null 2>&1 || true
 	@rm $(HOMEDIR)/lake $(HOMEDIR)/space $(HOMEDIR)/message $(HOMEDIR)/net $(HOMEDIR)/sidecar >/dev/null 2>&1 || true
 	@touch $(HOMEDIR)/config $(HOMEDIR)/alias
 	@ln -s $(SOURCE)/lake/ $(HOMEDIR)/lake
 	@ln -s $(SOURCE)/space/ $(HOMEDIR)/space
-	@ln -s $(SOURCE)/message/ $(HOMEDIR)/message
 	@ln -s $(SOURCE)/sidecar/ $(HOMEDIR)/sidecar
 	@sed $(SED_EXPR) ./model/Makefile > $(HOMEDIR)/Makefile
 	@cp ./model/gen.py $(HOMEDIR) && cp ./model/patch.py $(HOMEDIR) && cp ./model/helper.py $(HOMEDIR)
 	@cp -r ./scripts/ $(HOMEDIR)/scripts/ && chmod -R +x $(HOMEDIR)/scripts/
 	@cp -r $(SOURCE)/net/ $(HOMEDIR)/net && cat ./net/headscale/deploy/values.yaml | sed s+{{home}}+$(HOMEABS)+g > $(HOMEDIR)/net/headscale/deploy/values.yaml
+	@cp -r $(SOURCE)/message/ $(HOMEDIR)/message && cat ./message/emqx/deploy/values.yaml | sed s+{{home}}+$(HOMEABS)+g > $(HOMEDIR)/message/emqx/deploy/values.yaml
 
 .PHONY: python-digi
 python-digi:

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ ctx:
 	cd sidecar/ctx/cmd/ctx; go install .
 install: | digi neat ctx
 	@mkdir $(HOMEDIR) >/dev/null 2>&1 || true
-	@mkdir $(HOMEDIR)/headscale >/dev/null 2>&1 || true
-	@mkdir $(HOMEDIR)/emqx >/dev/null 2>&1 || true
+	@mkdir $(HOMEDIR)/pv >/dev/null 2>&1 || true
+	@mkdir $(HOMEDIR)/pv/headscale >/dev/null 2>&1 || true
+	@mkdir $(HOMEDIR)/pv/emqx >/dev/null 2>&1 || true
 	@mkdir $(HOMEDIR)/secrets >/dev/null 2>&1 || true
 	@rm $(HOMEDIR)/lake $(HOMEDIR)/space $(HOMEDIR)/message $(HOMEDIR)/net $(HOMEDIR)/sidecar >/dev/null 2>&1 || true
 	@touch $(HOMEDIR)/config $(HOMEDIR)/alias

--- a/cmd/digi/digi/command.go
+++ b/cmd/digi/digi/command.go
@@ -71,6 +71,7 @@ func init() {
 	runCmd.Flags().String("pv-size", "10Mi", "Persistent volume size")
 	runCmd.Flags().String("pv-path", "/mnt", "Persistent volume path")
 	runCmd.Flags().StringSlice("sidecar", []string{}, "List of sidecars to attach")
+	runCmd.Flags().StringP("secrets-file", "s", "", "Secrets file")
 	stopCmd.Flags().StringP("kind", "k", "", "Digi kind")
 
 	RootCmd.AddCommand(testCmd)

--- a/cmd/digi/digi/digi.go
+++ b/cmd/digi/digi/digi.go
@@ -749,6 +749,7 @@ var runCmd = &cobra.Command{
 		deployFile, _ := cmd.Flags().GetString("deploy-file")
 		persistentVolume, _ := cmd.Flags().GetBool("persistent-volume")
 		sidecars, _ := cmd.Flags().GetStringSlice("sidecar")
+		secretsFile, _ := cmd.Flags().GetString("secrets-file")
 
 		kopfLog := "false"
 		if k, _ := cmd.Flags().GetBool("kopf-log"); k {
@@ -801,6 +802,7 @@ var runCmd = &cobra.Command{
 					"KOPFLOG": kopfLog,
 					"RUNFLAG": runFlag,
 					"CR":      deployFile,
+					"SECRETS": secretsFile,
 				}, cmdStr, false, quiet); err == nil {
 					if !noAlias {
 						// TBD check potential race

--- a/cmd/digi/space/command.go
+++ b/cmd/digi/space/command.go
@@ -111,8 +111,10 @@ var startCmd = &cobra.Command{
 	Aliases: []string{"init"},
 	Run: func(cmd *cobra.Command, args []string) {
 		registryFile, _ := cmd.Flags().GetString("registry-file")
+		secretsFile, _ := cmd.Flags().GetString("secrets-file")
 		params := map[string]string{
 			"CR": registryFile,
+			"SECRETS": secretsFile,
 		}
 
 		if len(args) == 0 {
@@ -509,6 +511,7 @@ func init() {
 	// TBD delete digi space removes all running digis and controllers
 	RootCmd.AddCommand(startCmd)
 	startCmd.Flags().StringP("registry-file", "f", "cr.yaml", "Specify a file containing registry data")
+	startCmd.Flags().StringP("secrets-file", "s", "", "Secrets file")
 	RootCmd.AddCommand(stopCmd)
 
 	RootCmd.AddCommand(MountCmd)

--- a/cmd/digi/space/command.go
+++ b/cmd/digi/space/command.go
@@ -30,6 +30,7 @@ var (
 		"syncer":  true,
 		"mounter": true,
 		"emqx":    true,
+		"emqx-auth":    true,
 		"net":     true,
 		"sourcer": true,
 		"pipelet": true,

--- a/driver/digi/message/mqtt.py
+++ b/driver/digi/message/mqtt.py
@@ -10,7 +10,7 @@ DEBUG = False
 broker = 'emqx'
 port = 1883
 
-def connect_mqtt() -> mqtt_client:
+def connect_mqtt(username, password) -> mqtt_client:
     def on_connect(client, userdata, flags, rc):
         if rc == 0:
             digi.logger.info("Connected to digi MQTT broker")
@@ -19,6 +19,7 @@ def connect_mqtt() -> mqtt_client:
 
     # Client ID - used for tracking subscriptions; must be unique
     client = mqtt_client.Client(digi.name + '-ingest')
+    client.username_pw_set(username, password)
     client.on_connect = on_connect
     client.connect(broker, port)
     return client
@@ -42,7 +43,7 @@ def subscribe(client: mqtt_client):
 
     digi.logger.info(f"Listening for messages on topic {digi.name}")
 
-def start_listening():
-    client = connect_mqtt()
+def start_listening(username, password):
+    client = connect_mqtt(username, password)
     subscribe(client)
     client.loop_forever()

--- a/driver/digi/message/mqtt.py
+++ b/driver/digi/message/mqtt.py
@@ -43,7 +43,7 @@ def subscribe(client: mqtt_client):
 
     digi.logger.info(f"Listening for messages on topic {digi.name}")
 
-def start_listening(username, password):
+def start_listening(username="admin", password="digi_password"):
     client = connect_mqtt(username, password)
     subscribe(client)
     client.loop_forever()

--- a/message/emqx/README.md
+++ b/message/emqx/README.md
@@ -6,13 +6,13 @@ In order to run the EMQX digi space, use `digi space start emqx`.
 By default, this EMQX digi will allow all connections without username/password authentication. If you would like to require username/password authentication in order to connect to the broker, you can follow these steps:
 
 ### Set EMQX Web Dashboard Admin Account
-In your digi home directory (normally `~/.digi`), you should find a `secrets` subdirectory. Create file `emqx-dash-auth.yaml` with the following contents:
+In your digi home directory (normally `~/.digi`), you should find a `secrets` subdirectory. Create file `emqx.yaml` with the following contents:
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: emqx-dash-auth
+  name: {{ .Values.name }}
 type: Opaque
 stringData:
   username: "username"

--- a/message/emqx/README.md
+++ b/message/emqx/README.md
@@ -1,0 +1,44 @@
+# EMQX Digi Space
+## Running
+In order to run the EMQX digi space, use `digi space start emqx`.
+
+## Authentication
+By default, this EMQX digi will allow all connections without username/password authentication. If you would like to require username/password authentication in order to connect to the broker, you can follow these steps:
+
+### Set EMQX Web Dashboard Admin Account
+In your digi home directory (normally `~/.digi`), you should find a `secrets` subdirectory. Create file `emqx-dash-auth.yaml` with the following contents:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: emqx-dash-auth
+type: Opaque
+stringData:
+  username: "username"
+  password: "password"
+```
+
+Replace `username` and `password` with your desired username and password.
+
+**NOTE**: all passwords must be at least 8 characters in length.
+
+### Start EMQX Digi Space
+Execute `digi space start emqx` to start the space with the new credentials.
+
+### Log Into Web Dashboard
+The EMQX web dashboard is exposed on port 30004 on the local network as a NodePort. Simply connect to `http://localhost:30004` using a web browser and log in using your new account.
+
+### Delete other accounts
+If you have run the EMQX space before with a different configuration, your old account may still be listed as a user. You can manually delete the accounts once you've logged into the dashboard.
+
+### Enable Authentciation
+- Click "Authentication" on the sidebar
+- Click "Create +" at the top right
+- Click "Password-Based", and click "Next"
+- Click "Built-in Database", and click "Next"
+- Click "Create"
+- Click "Users"
+- Add a user with a custom username and password
+
+Now, all MQTT connections will require one of the listed usernames/passwords to match in order to authenticate the connection!

--- a/message/emqx/deploy/image/Dockerfile
+++ b/message/emqx/deploy/image/Dockerfile
@@ -1,5 +1,5 @@
 # Digi
-FROM python:3.8
+FROM python:3.8-bullseye
 WORKDIR /src/
 
 RUN git clone https://github.com/silveryfu/kopf.git && \

--- a/message/emqx/deploy/templates/actor.yaml
+++ b/message/emqx/deploy/templates/actor.yaml
@@ -20,6 +20,10 @@ spec:
         name: {{ .Values.name }}
     spec:
       serviceAccountName: {{ .Values.name }}
+      volumes:
+        - name: {{ .Values.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.name }}
       containers:
         - name: {{ .Values.name }}
           image: {{ .Values.image }}
@@ -45,12 +49,27 @@ spec:
             value: {{ .Values.lake | default "http://lake:6534" }}
           - name: ZED_LAKE # for backward compatibility TBD deprecate in v0.3
             value: {{ .Values.zed_lake | default "http://lake:6534" }}
+          - name: EMQX_DASH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: emqx-dash-auth
+                key: username
+                optional: true
+          - name: EMQX_DASH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: emqx-dash-auth
+                key: password
+                optional: true
           ports: # https://www.emqx.io/docs/en/v3.0/guide.html#start-emq-x-broker
           - containerPort: 1883  # MQTT
           - containerPort: 8883  # MQTT SSL
           - containerPort: 8083  # MQTT WebSocket
           - containerPort: 8080  # HTTP API
           - containerPort: 18083 # Dashboard console
+          volumeMounts:
+          - mountPath: /var/lib/emqx/
+            name: {{ .Values.name }}
 
 ---
 
@@ -60,7 +79,7 @@ metadata:
   name: {{ .Values.name }}
   labels:
     name: {{ .Values.name }}
-    digi.dev/type: kernel
+    app: emqx
 spec:
   type: NodePort # exposes nodePort to external network; must be in range 30000-32767
   ports: # emqx
@@ -91,3 +110,33 @@ spec:
     protocol: TCP
   selector:
     name: {{ .Values.name }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.name }}
+spec:
+  storageClassName: manual
+  persistentVolumeReclaimPolicy: Delete
+  capacity:
+    storage: {{ .Values.persistent_volume.size }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: {{ .Values.persistent_volume.path }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.name }}
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistent_volume.size }}

--- a/message/emqx/deploy/templates/actor.yaml
+++ b/message/emqx/deploy/templates/actor.yaml
@@ -79,7 +79,7 @@ metadata:
   name: {{ .Values.name }}
   labels:
     name: {{ .Values.name }}
-    app: emqx
+    digi.dev/type: kernel
 spec:
   type: NodePort # exposes nodePort to external network; must be in range 30000-32767
   ports: # emqx

--- a/message/emqx/deploy/templates/actor.yaml
+++ b/message/emqx/deploy/templates/actor.yaml
@@ -52,13 +52,13 @@ spec:
           - name: EMQX_DASH_USERNAME
             valueFrom:
               secretKeyRef:
-                name: emqx-dash-auth
+                name: emqx
                 key: username
                 optional: true
           - name: EMQX_DASH_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: emqx-dash-auth
+                name: emqx
                 key: password
                 optional: true
           ports: # https://www.emqx.io/docs/en/v3.0/guide.html#start-emq-x-broker

--- a/message/emqx/deploy/values.yaml
+++ b/message/emqx/deploy/values.yaml
@@ -8,5 +8,5 @@ namespace: default
 plural: emqxes
 version: v1
 persistent_volume:
-  path: {{home}}/.digi/emqx/
+  path: {{home}}/.digi/pv/emqx/
   size: 100Mi

--- a/message/emqx/deploy/values.yaml
+++ b/message/emqx/deploy/values.yaml
@@ -7,3 +7,6 @@ name: emqx
 namespace: default
 plural: emqxes
 version: v1
+persistent_volume:
+  path: {{home}}/.digi/emqx/
+  size: 100Mi

--- a/message/emqx/driver/handler.py
+++ b/message/emqx/driver/handler.py
@@ -1,12 +1,16 @@
 import sys
 import subprocess
-
+import os
 import digi
 
-
 if __name__ == '__main__':
+    # Default username and password
+    emqx_dash_username = os.environ.get("EMQX_DASH_USERNAME", "admin")
+    emqx_dash_password = os.environ.get("EMQX_DASH_PASSWORD", "digi_password")
+
     try:
-        subprocess.check_call("emqx start &", shell=True)
+        # Start EMQX, delete default admin account, delete old configured admin account, create new configured admin account
+        subprocess.check_call(f'emqx start; emqx ctl admins del admin; emqx ctl admins del {emqx_dash_username}; emqx ctl admins add {emqx_dash_username} {emqx_dash_password} &', shell=True)
     except subprocess.CalledProcessError:
         digi.logger.fatal("unable to start emqx")
         sys.exit(1)

--- a/model/Makefile
+++ b/model/Makefile
@@ -175,6 +175,7 @@ run: | prepare model delete-pool
 	cd $(build_dir)/deploy && mv $(CR) ./templates; \
 	helm template -f values.yaml --set name=$(NAME) $(RUNFLAG) $(NAME) . > run.yaml && \
 	kubectl delete -f run.yaml >/dev/null 2>&1 || true && \
+	kubectl apply -f $(SECRETS) >/dev/null || true && \
 	kubectl apply -f run.yaml >/dev/null || (echo "unable to run $(NAME), check $(CR)"; exit 1) && \
 	(kubectl exec `kubectl get pod --field-selector status.phase=Running -l app=lake -oname` \
     -- bash -c "zed create $(NAME)") >/dev/null && echo $(NAME) || echo "unable to create pool $(NAME); is lake running?"
@@ -270,7 +271,7 @@ stop-syncer:
 # message/emqx
 .PHONY: start-emqx stop-emqx
 start-emqx:
-	WORKDIR=$(DIGIHOME) digi run message/emqx emqx
+	WORKDIR=$(DIGIHOME) digi run message/emqx emqx -s $(DIGIHOME)/secrets/emqx-dash-auth.yaml
 stop-emqx:
 	digi stop emqx
 

--- a/model/Makefile
+++ b/model/Makefile
@@ -108,6 +108,7 @@ prepare-deploy:
 	rsync -r $(driver_dir)/deploy $(build_dir) || true
 	# app specific configs overwrite the generic ones
 	rsync -r $(digi_config) $(build_dir)/deploy || true
+	rsync $(SECRETS) $(build_dir)/deploy/templates || true
 prepare: | prepare-build-dir prepare-build prepare-deploy
 
 .PHONY: build clear-manifest
@@ -175,7 +176,6 @@ run: | prepare model delete-pool
 	cd $(build_dir)/deploy && mv $(CR) ./templates; \
 	helm template -f values.yaml --set name=$(NAME) $(RUNFLAG) $(NAME) . > run.yaml && \
 	kubectl delete -f run.yaml >/dev/null 2>&1 || true && \
-	kubectl apply -f $(SECRETS) >/dev/null || true && \
 	kubectl apply -f run.yaml >/dev/null || (echo "unable to run $(NAME), check $(CR)"; exit 1) && \
 	(kubectl exec `kubectl get pod --field-selector status.phase=Running -l app=lake -oname` \
     -- bash -c "zed create $(NAME)") >/dev/null && echo $(NAME) || echo "unable to create pool $(NAME); is lake running?"
@@ -191,6 +191,7 @@ stop: | delete-pool
 	((kubectl delete $(PLURAL) $(NAME) >/dev/null || \
 	kubectl delete $(PLURAL).$(VERSION).$(GROUP) $(NAME)) >/dev/null || true) & \
 	kubectl delete deployment $(NAME) >/dev/null && \
+	kubectl delete secret $(NAME) >/dev/null && \
 	echo $(NAME) || echo "$(NAME) isn't running"
 run-no-pool: | prepare model
 	cd $(build_dir)/deploy && mv $(CR) ./templates; \
@@ -269,10 +270,14 @@ stop-syncer:
 # TBD global mounter
 
 # message/emqx
-.PHONY: start-emqx stop-emqx
+.PHONY: start-emqx start-emqx-auth stop-emqx stop-emqx-auth
 start-emqx:
-	WORKDIR=$(DIGIHOME) digi run message/emqx emqx -s $(DIGIHOME)/secrets/emqx-dash-auth.yaml
+	WORKDIR=$(DIGIHOME) digi run message/emqx emqx
+start-emqx-auth:
+	WORKDIR=$(DIGIHOME) digi run message/emqx emqx -s $(DIGIHOME)/secrets/emqx.yaml
 stop-emqx:
+	digi stop emqx
+stop-emqx-auth:
 	digi stop emqx
 
 # net/headscale

--- a/model/Makefile
+++ b/model/Makefile
@@ -270,14 +270,14 @@ stop-syncer:
 # TBD global mounter
 
 # message/emqx
-.PHONY: start-emqx start-emqx-auth stop-emqx stop-emqx-auth
+.PHONY: start-emqx stop-emqx
 start-emqx:
-	WORKDIR=$(DIGIHOME) digi run message/emqx emqx
-start-emqx-auth:
-	WORKDIR=$(DIGIHOME) digi run message/emqx emqx -s $(DIGIHOME)/secrets/emqx.yaml
+ifeq ($(SECRETS),)
+	@WORKDIR=$(DIGIHOME) digi run message/emqx emqx
+else
+	@WORKDIR=$(DIGIHOME) digi run message/emqx emqx -s $(SECRETS)
+endif
 stop-emqx:
-	digi stop emqx
-stop-emqx-auth:
 	digi stop emqx
 
 # net/headscale

--- a/model/README.md
+++ b/model/README.md
@@ -25,7 +25,7 @@ For more information about Kubernetes secret files, view the documentation [here
 
 In order to use your secret, edit your `actor.yaml` file.
 
-One of the ways you can utilize your secret is by adding it as an environment variable to your digi. Under your `env` group, you can specify that an enviornment variable should be pulled from a secret as such:
+- One of the ways you can utilize your secret is by adding it as an environment variable to your digi. Under your `env` group, you can specify that an enviornment variable should be pulled from a secret as such:
 
 ```yaml
 env:

--- a/model/README.md
+++ b/model/README.md
@@ -1,3 +1,46 @@
 # Model
-
 Code generators and scripts to build, share, and deploy digis.
+
+## Adding secrets
+If you would like to run your digi with secrets, you can add secret files to the `secrets` subdirectory of your digi home (normally `~/.digi/secrets`).
+
+For good practice, try to title the file the same name as your secret name, i.e. `my-digi-auth.yaml`.
+
+Populate the secret file with the following contents:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-digi-auth
+type: Opaque
+stringData:
+  username: "username"
+  password: "password"
+```
+
+In the above example, change `my-digi-auth` to your secret's name.
+
+For more information about Kubernetes secret files, view the documentation [here](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/).
+
+In order to use your secret, edit your `actor.yaml` file.
+
+One of the ways you can utilize your secret is by adding it as an environment variable to your digi. Under your `env` group, you can specify that an enviornment variable should be pulled from a secret as such:
+
+```yaml
+env:
+- name: MY_DIGI_AUTH_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: my-digi-auth
+      key: username
+      optional: false
+- name: MY_DIGI_AUTH_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: my-digi-auth
+      key: password
+      optional: true
+```
+
+Finally, run your digi using the `-s` flag, which will specify the secret file to be used. For example, `digi run my-digi mydigi1 -s ~/.digi/my-digi-auth.yaml`.

--- a/net/headscale/deploy/values.yaml
+++ b/net/headscale/deploy/values.yaml
@@ -8,5 +8,5 @@ namespace: default
 plural: headscales
 version: v1
 persistent_volume:
-  path: {{home}}/.digi/headscale/
+  path: {{home}}/.digi/pv/headscale/
   size: 50Mi


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Adds the ability for digi developers to add secrets to their digis. These secret files are not committed to the digi code, and can be used for configuration or sensitive information (i.e. username/password, API key, etc).

The digi developer can instruct users to create a secret file in a brand-new `secrets` directory under the digi home directory, where they can store their secrets. Finally, the users can run their digis using the secrets file with a new CLI argument `-s`, which takes a secrets file and applies it to the digi kubernetes resource.

As a proof of concept, this feature is implemented in the EMQX digi space.

This PR also adds extensive documentation to cover the usage of secrets, and how to run the EMQX digi with secrets as well.

#### Does this PR introduce a user-facing change?
```release-note
Adds the ability for digi developers to add secrets to their digis. These secret files are not committed to the digi code, and can be used for configuration or sensitive information (i.e. username/password, API key, etc).

The digi developer can instruct users to create a secret file in a brand-new `secrets` directory under the digi home directory, where they can store their secrets. Finally, the users can run their digis using the secrets file with a new CLI argument `-s`, which takes a secrets file and applies it to the digi kubernetes resource.
```
