### PR TITLE
Created a webservice that processes user search queries and returns relevant digis

### DIFF
--- a/gpt/catalog/home1.yaml
+++ b/gpt/catalog/home1.yaml
@@ -1,0 +1,19 @@
+apiVersion: home.digi.dev/v1
+kind: Home
+metadata:
+  name: Soda
+  namespace: default
+spec:
+  control:
+    mode: "Auto"
+  mount:
+    home.digi.dev/v1/rooms:
+      default/livingRoom1:
+        brightness: 70
+        mode: "On"
+        mount:
+          home.digi.dev/v1/objects:
+            - class: "Lamp"
+              name: "Main Lamp 1"
+            - class: "Heater"
+              name: "Room Heater 1"

--- a/gpt/catalog/home2.yaml
+++ b/gpt/catalog/home2.yaml
@@ -1,0 +1,19 @@
+apiVersion: home.digi.dev/v1
+kind: Home
+metadata:
+  name: Cory
+  namespace: default
+spec:
+  control:
+    mode: "Auto"
+  mount:
+    home.digi.dev/v1/rooms:
+      default/livingRoom2:
+        brightness: 75
+        mode: "On"
+        mount:
+          home.digi.dev/v1/objects:
+            - class: "Fan"
+              name: "Main Fan 2"
+            - class: "TV"
+              name: "Room TV 2"

--- a/gpt/catalog/home3.yaml
+++ b/gpt/catalog/home3.yaml
@@ -1,0 +1,20 @@
+apiVersion: home.digi.dev/v1
+kind: Home
+metadata:
+  name: Apartement
+  namespace: default
+spec:
+  control:
+    mode: "Auto"
+  mount:
+    home.digi.dev/v1/rooms:
+      default/livingRoom3:
+        brightness: 80
+        mode: "On"
+        mount:
+          home.digi.dev/v1/objects:
+            - class: "Lamp"
+              name: "Main Lamp 3"
+            - class: "Heater"
+              name: "Room Heater 3"
+

--- a/gpt/catalog/home4.yaml
+++ b/gpt/catalog/home4.yaml
@@ -1,0 +1,20 @@
+apiVersion: home.digi.dev/v1
+kind: Home
+metadata:
+  name: Office
+  namespace: default
+spec:
+  control:
+    mode: "Auto"
+  mount:
+    home.digi.dev/v1/rooms:
+      default/livingRoom4:
+        brightness: 85
+        mode: "On"
+        mount:
+          home.digi.dev/v1/objects:
+            - class: "Fan"
+              name: "Main Fan 4"
+            - class: "TV"
+              name: "Room TV 4"
+

--- a/gpt/catalog/home5.yaml
+++ b/gpt/catalog/home5.yaml
@@ -1,0 +1,19 @@
+apiVersion: home.digi.dev/v1
+kind: Home
+metadata:
+  name: Mall
+  namespace: default
+spec:
+  control:
+    mode: "Auto"
+  mount:
+    home.digi.dev/v1/rooms:
+      default/livingRoom5:
+        brightness: 90
+        mode: "On"
+        mount:
+          home.digi.dev/v1/objects:
+            - class: "Lamp"
+              name: "Main Lamp 5"
+            - class: "Heater"
+              name: "Room Heater 5"

--- a/gpt/frontend/index.html
+++ b/gpt/frontend/index.html
@@ -26,7 +26,7 @@
             width: 300px;
             padding: 10px;
             border: 1px solid #ccc;
-            border-radius: 3px;
+            border-radius: 5px;
         }
 
         .search-btn {
@@ -34,16 +34,74 @@
             background-color: #007BFF;
             color: #fff;
             border: none;
-            border-radius: 3px;
+            border-radius: 5px;
             cursor: pointer;
             margin-left: 10px;
         }
+
+        .results {
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+
+        .vertical-stack {
+            display: flex;
+            flex-direction: column;
+            gap: 5px;
+        }
+
+        .horiztonal-stack {
+            display: flex;
+            flex-direction: row;
+            gap: 5px;
+        }
+
+        #backend-url {
+            min-width: 360px;
+            box-sizing: border-box;
+            margin-bottom: 5px;
+            border: 1px solid #ccc;
+            padding: 10px;
+            border-radius: 5px;
+        }
+
     </style>
 </head>
 <body>
+    <div class="vertical-stack">
     <div class="search-container">
-        <input type="text" class="search-bar" placeholder="Intent...">
-        <button class="search-btn">Chat</button>
+        <div class="config-container">
+            <div class="horiztonal-stack">
+                <p>Backend Host URL: </p>
+                <input type="text" id="backend-url" placeholder="Enter Flask App URL (e.g., http://127.0.0.1:5000)">
+            </div>
+            
+        </div>
+        <div class="horiztonal-stack">
+            <p>Search Query: </p>
+            <input type="text" class="search-bar" placeholder="Intent...">
+            <button class="search-btn">Chat</button>
+        </div>
+        
     </div>
+    <div class="results">Search Results: </div>
+</div>
+    <script>
+        document.querySelector('.search-btn').addEventListener('click', function () {
+            let intent = document.querySelector('.search-bar').value;
+            let backendURL = document.getElementById('backend-url').value;
+            fetch(`${backendURL}/query?search=${intent}`)
+                .then(response => response.json())
+                .then(data => {
+                    let resultsDiv = document.querySelector('.results');
+                    resultsDiv.innerHTML = 'Matched Digis: ' + data.homes.map(home => home.metadata.name).join(', ');
+                })
+                .catch(error => {
+                    console.error('Error fetching data:', error);
+                });
+        });
+    </script>
 </body>
 </html>

--- a/gpt/intent/QueryProcessing.py
+++ b/gpt/intent/QueryProcessing.py
@@ -1,0 +1,86 @@
+import aiofiles
+import asyncio
+import yaml
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+class QueryProcessor:
+    @staticmethod
+    async def load_yaml(filename: str) -> dict:
+        """
+        Load a YAML file and return its contents as a dictionary.
+
+        Args:
+            filename (str): The path to the YAML file.
+
+        Returns:
+            dict: The contents of the YAML file as a dictionary.
+        """
+        async with aiofiles.open(filename, 'r') as file:
+            data = await file.read()
+        return yaml.safe_load(data)
+
+    @staticmethod
+    async def get_homes(folder: str, num: int) -> list:
+        """
+        Load multiple YAML files from a folder and return their contents as a list.
+
+        Args:
+            folder (str): The path to the folder containing the YAML files.
+            num (int): The number of YAML files to load.
+
+        Returns:
+            list: A list of dictionaries, where each dictionary contains the contents of a YAML file.
+        """
+        return await asyncio.gather(*[QueryProcessor.load_yaml(folder + f"home{i+1}.yaml") for i in range(num)])
+
+    @staticmethod
+    def vectorize(data: list) -> np.ndarray:
+        """
+        Vectorize a list of sentences using SentenceTransformer.
+
+        Args:
+            data (list): A list of sentences to vectorize.
+
+        Returns:
+            np.ndarray: A numpy array containing the vector representations of the input sentences.
+        """
+        model = SentenceTransformer('paraphrase-MiniLM-L6-v2')
+        return model.encode(data, convert_to_numpy=True)
+
+    @staticmethod
+    def similarity_search(user_vector: np.ndarray, digi_vectors: np.ndarray, num: int) -> np.ndarray:
+        """
+        Perform a similarity search to identify the closest vectors to the user's query.
+
+        Args:
+            user_vector (np.ndarray): The vector representation of the user's query.
+            digi_vectors (np.ndarray): A numpy array containing the vector representations of the available options.
+            num (int): The number of closest options to return.
+
+        Returns:
+            np.ndarray: A numpy array containing the indices of the closest options.
+        """
+        distances = np.dot(digi_vectors, user_vector) / (np.linalg.norm(digi_vectors, axis=1) * np.linalg.norm(user_vector))
+        top_indices = distances.argsort()[-num:][::-1]
+        return top_indices
+
+    @staticmethod
+    def extract_names_from_mount(mount: dict) -> list:
+        """
+        Recursively extract names from mount sections.
+
+        Args:
+            mount (dict): A dictionary containing mount sections.
+
+        Returns:
+            list: A list of names extracted from the mount sections.
+        """
+        names = []
+        for value in mount.values():
+            if isinstance(value, dict):
+                if 'name' in value:
+                    names.append(value['name'])
+                else:
+                    names.extend(QueryProcessor.extract_names_from_mount(value))
+        return names

--- a/gpt/intent/__init__.py
+++ b/gpt/intent/__init__.py
@@ -1,0 +1,51 @@
+import yaml
+import asyncio
+import aiofiles
+import numpy as np
+from flask_cors import CORS
+from flask import Flask, request, jsonify, make_response
+from sentence_transformers import SentenceTransformer
+from QueryProcessing import QueryProcessor
+
+app: Flask = Flask(__name__)
+CORS(app)
+
+app = Flask(__name__)
+
+@app.route('/query', methods=['GET'])
+def handle_query() -> None:
+    """
+    Handles the user's search query.
+
+    Returns:
+        A list of 3 digis which relate to the user's search query the most. (Relation is based on cosine similarity.)
+    """
+    user_query: str = request.args.get('search', default='')
+    DATA_FOLDER: str = "../catalog/"
+    loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+    homes: list = loop.run_until_complete(QueryProcessor.get_homes(DATA_FOLDER, 5))
+    concatenated_data: list = []
+    for home in homes:
+        home_name: str = home['metadata']['name']
+        objects_names: list = QueryProcessor.extract_names_from_mount(home['spec']['mount'])
+        concatenated_string: str = home_name + ' ' + ' '.join(objects_names)
+        concatenated_data.append(concatenated_string)
+    user_vector: np.ndarray = QueryProcessor.vectorize(user_query)
+    digi_vectors: np.ndarray = QueryProcessor.vectorize(concatenated_data)
+    top_matches: list = QueryProcessor.similarity_search(user_vector, digi_vectors, 3)
+    matched_homes: list = [homes[i] for i in top_matches]
+    response: make_response = make_response(jsonify({"homes": matched_homes}))
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
+
+@app.route('/', methods=['GET'])
+def home_page() -> str:
+    """Default web service route.
+    
+    Returns:
+        A welcome message and instructures on accessing other endpoints in the service. 
+    """
+    return "Welcome to Digi Intent Processing Web Service. Use /query?search=<search query> to receive the digis assocaited with the particular search query."
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

My task this week was to add functionality to the SpaceGPT query screen to take a query and output the names of the relevant devices or digis that the query should invoke. 

For this task I focused on three main parts of the codebase: 
Catalog: This is where the data (models of the existing digi devices) are stored. 
Intent: This is where the query is processed and the similarity search is done. 
GPT/Frontend: This is where the frontend code lives. 

My task is split into two parts: 
Web Service/Backend: Flask (Catalog/Intent)
Frontend: JS

The pipeline of the task can be summarized as follows: 

- I create sample data (digi models) from ChatGPT using the scheme for homes/rooms via the mocks sub-directory. 
- I receive a query (intent) from the user. 
- I use pgvector-python’s Sentence Transformer to vectorize it. Also, asynchronously, I will vectorize the sample digi models. 
- I then use pgvector’s similarity search options to identify the relevant digis. 
- I parse out their names from their respective embeddings and return a list of digi names. 
- Finally, I display the names on the frontend. 


#### Which issue(s) this PR fixes:
This is a feature PR. Doesn't fix any existing issue. 

#### Special notes for your reviewer:
To test the code please start the flask server by entering the `/gpt/intent` directory and then running `python3 __init__.py` to start the flask server. (Please make sure the relevant pip dependencies have been installed on your computer) Then take the server host url information (i.e. `http://127.0.0.1:5000)` and open the GPT frontend webpage by running `index.html` in your browser of choice. Finally, just paste the host url information in the appropriate box, type your search query, and hit the chat button. Then the three most relevant digis' names should be displayed. Note: the usage of this manual host typing procedure is temporary and can be removed once the web service is deployed. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

Yes. 

```release-note
```
